### PR TITLE
Power noise

### DIFF
--- a/decoder/src/decoder.c
+++ b/decoder/src/decoder.c
@@ -382,10 +382,11 @@ int update_subscription(pkt_len_t pkt_len, subscription_update_packet_t *update)
     uint8_t device_id_bytes[sizeof(decoder_id_t)]; // buffer for device id
     memcpy(device_id_bytes, &update->decoder_id, sizeof(decoder_id_t));
 
+    add_power_noise();
     // Create device-specific key input buffer
     uint32_t device_key_input_size = SUBSCRIPTION_KEY_SIZE + sizeof(decoder_id_t);
     uint8_t device_key_input[SUBSCRIPTION_KEY_SIZE + sizeof(decoder_id_t)];
-
+    add_power_noise();
     // Initialize device key input 
     memset(device_key_input, 0, device_key_input_size);
     memcpy(device_key_input, key_bytes, SUBSCRIPTION_KEY_SIZE); // Copy data
@@ -394,8 +395,10 @@ int update_subscription(pkt_len_t pkt_len, subscription_update_packet_t *update)
     // Hash to create device key (master key + device ID)
     memset(device_key, 0, HASH_SIZE);
     int hash_result = hash(device_key_input, device_key_input_size, device_key);
+    add_power_noise();
 
     if (hash_result != 0) {
+        add_power_noise();
         char error_buf[64];
         sprintf(error_buf, "WolfSSL hash returned error: %d", hash_result);
         print_debug(error_buf);
@@ -506,7 +509,8 @@ int decode(pkt_len_t pkt_len, frame_packet_t *new_frame) {
     unsigned char *ciphertext = new_frame->data; // Extract Ciphertext
     unsigned char *auth_tag = new_frame->auth_tag; // Extract auth_tag (HMAC)
 
-    // Verify HMAC first
+    // Verify HMAC 
+    add_power_noise();
     uint8_t computed_hmac[HASH_SIZE];
     uint8_t hmac_input[sizeof(channel_id_t) + sizeof(timestamp_t) + 16 + ciphertext_size];
 
@@ -524,7 +528,7 @@ int decode(pkt_len_t pkt_len, frame_packet_t *new_frame) {
 
 
     // Get MAC key from secrets
-
+    add_power_noise();
     uint8_t mac_key [MAC_KEY_SIZE];
     load_mac_key(mac_key);
     add_power_noise();

--- a/decoder/src/decoder.c
+++ b/decoder/src/decoder.c
@@ -243,15 +243,21 @@ static int constant_time_memcmp(const void* a, const void* b, size_t len) {
  * 
  */
 static void add_power_noise(void) {
+    
+
     // Create volatile buffers that won't be optimized out by compiler
     volatile uint8_t noise_buffer[32];
     volatile uint8_t result_buffer[32];
     
+    MXC_TRNG_Init();
+
     // Use hardware TRNG to get random data
     for (int i = 0; i < sizeof(noise_buffer); i++) {
         MXC_TRNG_Random((uint8_t*)&noise_buffer[i], 1);
     }
     
+    MXC_TRNG_Shutdown();
+
     // Perform dummy arithmetic operations that consume power in a data-independent manner
     for (int i = 0; i < sizeof(noise_buffer); i++) {
         // Mix operations that consume different power
@@ -259,14 +265,17 @@ static void add_power_noise(void) {
         result_buffer[i] += (noise_buffer[(i+7) % sizeof(noise_buffer)] & 0xAA);
         result_buffer[i] *= (noise_buffer[(i+13) % sizeof(noise_buffer)] | 0x33);
         
+
         // Add compiler memory barriers to prevent optimization
         __asm__ volatile("" : : : "memory");
         
+
         // Ensure variable number of operations to create timing jitter
         uint8_t iterations = (noise_buffer[i] & 0x07) + 1;
         for (uint8_t j = 0; j < iterations; j++) {
             result_buffer[i] ^= (result_buffer[(i+j) % sizeof(result_buffer)] + j);
         }
+
     }
     
     // Force use of results to prevent compiler optimizations
@@ -588,6 +597,7 @@ void init() {
 
     // Initialize the flash peripheral to enable access to persistent memory
     flash_simple_init();
+
 
     // Read starting flash values into our flash status struct
     flash_simple_read(FLASH_STATUS_ADDR, &decoder_status, sizeof(flash_entry_t));

--- a/decoder/src/decoder.c
+++ b/decoder/src/decoder.c
@@ -25,6 +25,7 @@
 #include "secret_keys.h"
 #include "user_settings.h"
 #include "simple_crypto.h"
+#include "trng.h"
 
 /**********************************************************
  ******************* PRIMITIVE TYPES **********************

--- a/decoder/src/decoder.c
+++ b/decoder/src/decoder.c
@@ -235,6 +235,52 @@ static int constant_time_memcmp(const void* a, const void* b, size_t len) {
     return (result != 0);
 }
 
+/**
+ * @brief Add noise to power consumption to protect against power analysis attacks
+ * 
+ * This function executes random operations to mask power analysis during sensitive/cryptographic operations.
+ * 
+ */
+static void add_power_noise(void) {
+    // Create volatile buffers that won't be optimized out by compiler
+    volatile uint8_t noise_buffer[32];
+    volatile uint8_t result_buffer[32];
+    
+    // Use hardware TRNG to get random data
+    for (int i = 0; i < sizeof(noise_buffer); i++) {
+        MXC_TRNG_Random((uint8_t*)&noise_buffer[i], 1);
+    }
+    
+    // Perform dummy arithmetic operations that consume power in a data-independent manner
+    for (int i = 0; i < sizeof(noise_buffer); i++) {
+        // Mix operations that consume different power
+        result_buffer[i] = (noise_buffer[i] ^ 0x55);
+        result_buffer[i] += (noise_buffer[(i+7) % sizeof(noise_buffer)] & 0xAA);
+        result_buffer[i] *= (noise_buffer[(i+13) % sizeof(noise_buffer)] | 0x33);
+        
+        // Add compiler memory barriers to prevent optimization
+        __asm__ volatile("" : : : "memory");
+        
+        // Ensure variable number of operations to create timing jitter
+        uint8_t iterations = (noise_buffer[i] & 0x07) + 1;
+        for (uint8_t j = 0; j < iterations; j++) {
+            result_buffer[i] ^= (result_buffer[(i+j) % sizeof(result_buffer)] + j);
+        }
+    }
+    
+    // Force use of results to prevent compiler optimizations
+    uint8_t checksum = 0;
+    for (int i = 0; i < sizeof(result_buffer); i++) {
+        checksum ^= result_buffer[i];
+    }
+    
+    // Use the checksum in a way that doesn't affect program logic
+    // but prevents the compiler from removing the code
+    if (checksum == 0xFF) {
+        // This branch almost never executes, but compiler can't prove it ;)
+        __asm__ volatile("nop");
+    }
+}
 
 /**********************************************************
  ********************* CORE FUNCTIONS *********************
@@ -315,9 +361,12 @@ int update_subscription(pkt_len_t pkt_len, subscription_update_packet_t *update)
     memcpy(verify_buffer + sizeof(decoder_id_t) + sizeof(timestamp_t) * 2,
         &update->channel, sizeof(channel_id_t));
 
-    // Get subscription/master key using the load_subscription_key function
+    // Get subscription/master key using the load_subscription_key 
+    // mask power signal
+    add_power_noise();
     uint8_t key_bytes[SUBSCRIPTION_KEY_SIZE];
     load_subscription_key(key_bytes);
+    add_power_noise();
 
     // Convert device ID to bytes (similar to Python format)
     uint8_t device_id_bytes[sizeof(decoder_id_t)]; // buffer for device id
@@ -346,9 +395,11 @@ int update_subscription(pkt_len_t pkt_len, subscription_update_packet_t *update)
     }
 
     // Compute HMAC: H((device key ⊕ opad) || H((device key ⊕ ipad) || verify buffer))
+    add_power_noise();
     hash_result = compute_hmac(device_key, HASH_SIZE, verify_buffer, sizeof(verify_buffer), computed_hash);
 
     if (hash_result != 0) {
+        add_power_noise();
         char error_buf[64];
         sprintf(error_buf, "WolfSSL hash returned error: %d", hash_result);
         print_debug(error_buf);
@@ -358,6 +409,7 @@ int update_subscription(pkt_len_t pkt_len, subscription_update_packet_t *update)
     }
 
     // Securely clear the key from memory when done
+    add_power_noise();
     secure_clear(key_bytes, SUBSCRIPTION_KEY_SIZE);
     secure_clear(device_key_input, device_key_input_size);
 

--- a/decoder/src/decoder.c
+++ b/decoder/src/decoder.c
@@ -367,7 +367,7 @@ int update_subscription(pkt_len_t pkt_len, subscription_update_packet_t *update)
     uint8_t key_bytes[SUBSCRIPTION_KEY_SIZE];
     load_subscription_key(key_bytes);
     add_power_noise();
-
+    // TODO: should any of this before HMAC have power noise?
     // Convert device ID to bytes (similar to Python format)
     uint8_t device_id_bytes[sizeof(decoder_id_t)]; // buffer for device id
     memcpy(device_id_bytes, &update->decoder_id, sizeof(decoder_id_t));
@@ -501,30 +501,37 @@ int decode(pkt_len_t pkt_len, frame_packet_t *new_frame) {
     uint8_t hmac_input[sizeof(channel_id_t) + sizeof(timestamp_t) + 16 + ciphertext_size];
 
     // Construct data in same manner as HMAC in encoder
+    add_power_noise();
     memcpy(hmac_input, &new_frame->channel, sizeof(channel_id_t));
     memcpy(hmac_input + sizeof(channel_id_t), &new_frame->timestamp, sizeof(timestamp_t));
     memcpy(hmac_input + sizeof(channel_id_t) + sizeof(timestamp_t), iv, 16);
     memcpy(hmac_input + sizeof(channel_id_t) + sizeof(timestamp_t) + 16, ciphertext, ciphertext_size);
 
     // Get encryption key from secrets
+    add_power_noise();
     uint8_t encryption_key[ENCRYPTION_KEY_SIZE];
     load_encryption_key(encryption_key);
 
+
     // Get MAC key from secrets
+
     uint8_t mac_key [MAC_KEY_SIZE];
     load_mac_key(mac_key);
+    add_power_noise();
 
     // Compute HMAC
     compute_hmac(mac_key, MAC_KEY_SIZE, hmac_input, sizeof(hmac_input), computed_hmac);
-
+    add_power_noise();
     // Verify HMAC in constant time
     if (constant_time_memcmp(computed_hmac, auth_tag, HASH_SIZE) != 0) {
+        add_power_noise();
         secure_clear(mac_key, MAC_KEY_SIZE);
         MXC_Delay(MXC_DELAY_MSEC(5000));
         STATUS_LED_ERROR();
         print_error("Failed to authenticate frame - invalid signature\n");
         return -1;
-    } 
+    }
+    add_power_noise();
     secure_clear(mac_key, MAC_KEY_SIZE); // clear mac key buffer
     
     //CHECKS IF SECURITY CHECKS PASSED
@@ -542,10 +549,12 @@ int decode(pkt_len_t pkt_len, frame_packet_t *new_frame) {
         uint8_t decrypted_data[FRAME_SIZE];
         int decrypted_size;
 
+        add_power_noise();
         decrypted_size = aes_decrypt(ciphertext, ciphertext_size, encryption_key, iv, decrypted_data);
         if (decrypted_size < 0) {
 
             // clear encryption key
+            add_power_noise();
             secure_clear(encryption_key, ENCRYPTION_KEY_SIZE); 
 
             // IPS DELAYS 5 SECONDS ON DECRYPTION FAILURE
@@ -557,6 +566,7 @@ int decode(pkt_len_t pkt_len, frame_packet_t *new_frame) {
         }
 
         // clear encryption key
+        add_power_noise();
         secure_clear(encryption_key, ENCRYPTION_KEY_SIZE); 
         write_packet(DECODE_MSG, decrypted_data, FRAME_SIZE); // 
         return 0;

--- a/decoder/src/decoder.c
+++ b/decoder/src/decoder.c
@@ -25,7 +25,6 @@
 #include "secret_keys.h"
 #include "user_settings.h"
 #include "simple_crypto.h"
-#include "trng.h"
 
 /**********************************************************
  ******************* PRIMITIVE TYPES **********************

--- a/decoder/src/simple_crypto.c
+++ b/decoder/src/simple_crypto.c
@@ -21,6 +21,7 @@
 // Using wolfSSL for SHA-256 & AES
 #include "wolfssl/wolfcrypt/sha256.h"
 #include <wolfssl/wolfcrypt/aes.h>
+#include "trng.h"
 
 /***********************************************************************************************************
  @brief AES Decryption function using wolfSSL


### PR DESCRIPTION
Defined add_power_noise() in decoder.c which generates random numbers and computes some dummy operations to mask sensitive cryptographic hardware signals.

This function should be called before AND after any cryptographic operations, like loading keys, verifying/computing HMAC, and AES decryption. It is meant to sandwich sensitive signals with noise to make them hard to distinguish.